### PR TITLE
Fix Migrate Rollback, missing grammar property on Builder class.

### DIFF
--- a/src/Mpociot/Couchbase/Schema/Builder.php
+++ b/src/Mpociot/Couchbase/Schema/Builder.php
@@ -13,6 +13,7 @@ class Builder extends \Illuminate\Database\Schema\Builder
     public function __construct(Connection $connection)
     {
         $this->connection = $connection;
+        $this->grammar    = $connection->getSchemaGrammar();
     }
 
     /**


### PR DESCRIPTION
The builder class was missing the grammar property, this made the migration rollback command to fail.