### PR TITLE
Illuminate BluePrint constructor fix

### DIFF
--- a/src/Mpociot/Couchbase/Schema/Builder.php
+++ b/src/Mpociot/Couchbase/Schema/Builder.php
@@ -94,6 +94,6 @@ class Builder extends \Illuminate\Database\Schema\Builder
      */
     protected function createBlueprint($collection, Closure $callback = null)
     {
-        return new Blueprint($this->connection, $collection);
+        return new Blueprint($collection, $callback);
     }
 }


### PR DESCRIPTION
Illuminate Blueprint constructor requires two params: table and callback (instance of Closure).

Builder was passing wrong data into constructor.