### PR TITLE
fix Model error in Laravel 5.6 and 5.7

### DIFF
--- a/src/Mpociot/Couchbase/Eloquent/Model.php
+++ b/src/Mpociot/Couchbase/Eloquent/Model.php
@@ -148,7 +148,7 @@ abstract class Model extends BaseModel
      *
      * @return string
      */
-    protected function getDateFormat()
+    public function getDateFormat()
     {
         return $this->dateFormat ?: 'Y-m-d H:i:s';
     }


### PR DESCRIPTION
for compactible with Laravel 5.6 and 5.7 this error should be fix.

Access level to Mpociot\Couchbase\Eloquent\Model::getDateFormat() must be public (as in class Illuminate\Database\Eloquent\Model)  is.